### PR TITLE
Fix a bug when config_file doesn't exist

### DIFF
--- a/lib/aws_config/store.rb
+++ b/lib/aws_config/store.rb
@@ -2,7 +2,11 @@ module AWSConfig
   module Store
     def profiles
       @profiles ||= begin
-        Parser.parse(File.read(config_file))
+        if File.exists?(config_file)
+          Parser.parse(File.read(config_file))
+        else
+          Hash.new
+        end
       end
     end
 


### PR DESCRIPTION
_aws_config_ will fail if the specified `config_file` doesn't exist.

Please publish a new gem if you merge this PR. I want to use it in another library :)
