### PR TITLE
Chained Profile & Shared Credentials Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,36 +18,66 @@ Or install it yourself as:
 
 ## Usage
 
-It parses `~/.aws/config` by default.
+It parses `~/.aws/config` and `~/.aws/credentials` by default.
 
-If you put a config file like:
+If your aws config files look like this:
 
-    [default]
-    aws_access_key_id=DefaultAccessKey01
-    aws_secret_access_key=Default/Secret/Access/Key/02
-    # Optional, to define default region for this profile.
-    region=us-west-1
+**Credentials file**
+```
+  [default]
+  aws_access_key_id=DefaultAccessKey01
+  aws_secret_access_key=Default/Secret/Access/Key/02
 
-    [profile testing]
-    aws_access_key_id=TestingAccessKey03
-    aws_secret_access_key=Testing/Secret/Access/Key/04
-    region=us-west-2
+  [testing]
+  aws_access_key_id=TestingAccessKey03
+  aws_secret_access_key=Testing/Secret/Access/Key/04
+```
+
+**Config file**
+```
+  [default]
+  # Optional, to define default region for this profile.
+  region=us-west-1
+  source_profile=default
+
+  [profile testing]
+  role_arn=arn:example:283671836
+  region=us-west-2
+  source_profile=testing
+
+  [profile with_mfa]
+  source_profile=testing
+  region=ap-southeast-2
+  mfa_serial=arn:mfa_device:151235152134
+```
 
 you can access it like:
+```ruby
+  require "aws_config"
 
-    require "aws_config"
-    
-    puts AWSConfig.default.aws_access_key_id    #=> DefaultAccessKey01
-    puts AWSConfig.default.region               #=> Default/Secret/Access/Key/02
+  puts AWSConfig.default.aws_access_key_id    #=> DefaultAccessKey01
+  puts AWSConfig.default.region               #=> Default/Secret/Access/Key/02
+```
 
 also you can do like hashes:
+```ruby
+  puts AWSConfig["default"]["aws_access_key_id"]  #=> DefaultAccessKey01
+  puts AWSConfig["default"]["region"]             #=> Default/Secret/Access/Key/02
+```
 
-    puts AWSConfig["default"]["aws_access_key_id"]  #=> DefaultAccessKey01
-    puts AWSConfig["default"]["region"]             #=> Default/Secret/Access/Key/02
+If your config contains chained profiles using the `source_profile` property,
+you can still access the source profiles properties from the top i.e
+```ruby
+  require 'aws_config'
+
+  puts AWSConfig.with_mfa.role_arn #=> arn:example:283671836
+  puts AWSConfig.with_mfa.region   #=> ap-southeast-2
+```
 
 If you want to use with aws-sdk-ruby, you can configure like:
-
-    AWS.config(AWSConfig.default.config_hash)
+```ruby
+  AWS.config(AWSConfig.default.config_hash)
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ also you can do like hashes:
 If your config contains chained profiles using the `source_profile` property,
 you can still access the source profiles properties from the top i.e
 ```ruby
-  require 'aws_config'
+  require "aws_config"
 
   puts AWSConfig.with_mfa.role_arn #=> arn:example:283671836
   puts AWSConfig.with_mfa.region   #=> ap-southeast-2

--- a/lib/aws_config/parser.rb
+++ b/lib/aws_config/parser.rb
@@ -3,8 +3,12 @@ require "aws_config/profile"
 
 module AWSConfig
   class Parser
-    def self.parse(string)
-      new.parse(string)
+    attr_accessor :credential_file_mode
+
+    def self.parse(string, credential_file_mode = false)
+      parser = new
+      parser.credential_file_mode = credential_file_mode
+      parser.parse(string)
     end
 
     def parse(string)
@@ -12,7 +16,7 @@ module AWSConfig
     end
 
     private
-      
+
       def tokenize(string)
         s = StringScanner.new(string)
         tokens  = []
@@ -23,6 +27,8 @@ module AWSConfig
               tokens << [:profile, "default"]
             elsif m = s[1].match(/profile\s+([^\s]+)$/)
               tokens << [:profile, m[1]]
+            elsif credential_file_mode
+              tokens << [:profile, s[1]]
             end
           elsif s.scan(/([^\s=#]+)\s*=\s*([^\s#]+)/)
             tokens << [:key_value, s[1], s[2]]

--- a/lib/aws_config/profile.rb
+++ b/lib/aws_config/profile.rb
@@ -11,14 +11,25 @@ module AWSConfig
       key = key.to_s
       if entries.has_key?(key)
         entries[key]
+      elsif source_profile?
+        entries['source_profile'][key]
       else
         nil
       end
     end
 
+    def []=(key, value)
+      key = key.to_s
+      entries[key] = value
+    end
+
     def has_key?(key)
       key = key.to_s
       entries.has_key?(key)
+    end
+
+    def source_profile?
+      entries.key?('source_profile') && entries['source_profile'].is_a?(Profile)
     end
 
     def respond_to?(id, include_all = false)
@@ -28,6 +39,12 @@ module AWSConfig
     def method_missing(id, *args)
       if has_key?(id)
         self[id]
+      elsif source_profile?
+        if entries['source_profile'].respond_to?(id)
+          entries['source_profile'].send(id, args)
+        else
+          super
+        end
       else
         super
       end
@@ -35,10 +52,21 @@ module AWSConfig
 
     def config_hash
       {
-        access_key_id:      entries["aws_access_key_id"],
-        secret_access_key:  entries["aws_secret_access_key"],
-        region:             entries["region"]
+        access_key_id:      self["aws_access_key_id"],
+        secret_access_key:  self["aws_secret_access_key"],
+        region:             self["region"]
       }
+    end
+
+    # Returns a new profile from the two merged profiles
+    def merge(profile)
+      merged = entries.dup
+      merged.merge! profile.entries
+      new name, merged
+    end
+
+    def merge!(profile)
+      entries.merge! profile.entries
     end
   end
 end

--- a/lib/aws_config/profile.rb
+++ b/lib/aws_config/profile.rb
@@ -12,7 +12,7 @@ module AWSConfig
       if entries.has_key?(key)
         entries[key]
       elsif source_profile?
-        entries['source_profile'][key]
+        entries["source_profile"][key]
       else
         nil
       end
@@ -29,7 +29,7 @@ module AWSConfig
     end
 
     def source_profile?
-      entries.key?('source_profile') && entries['source_profile'].is_a?(Profile)
+      entries.key?("source_profile") && entries["source_profile"].is_a?(Profile)
     end
 
     def respond_to?(id, include_all = false)
@@ -40,8 +40,8 @@ module AWSConfig
       if has_key?(id)
         self[id]
       elsif source_profile?
-        if entries['source_profile'].respond_to?(id)
-          entries['source_profile'].send(id, args)
+        if entries["source_profile"].respond_to?(id)
+          entries["source_profile"].send(id, args)
         else
           super
         end

--- a/lib/aws_config/profile.rb
+++ b/lib/aws_config/profile.rb
@@ -67,6 +67,7 @@ module AWSConfig
 
     def merge!(profile)
       entries.merge! profile.entries
+      self
     end
   end
 end

--- a/lib/aws_config/profile_resolver.rb
+++ b/lib/aws_config/profile_resolver.rb
@@ -1,0 +1,43 @@
+require 'aws_config/profile'
+
+module AWSConfig
+  class ProfileResolver
+    attr_reader :profiles, :wanted_profiles
+
+    def initialize
+      @profiles = {}
+      @wanted_profiles = {}
+    end
+
+    def add(profs)
+      profs.each do |name, profile|
+        if profiles.key? name
+          profiles[name].merge! profile
+        else
+          profiles[name] = profile
+        end
+        resolve_source_profile(name, profile) if profile.has_key? 'source_profile'
+        provides_source_profile(name, profile)
+      end
+    end
+
+    private
+
+    def resolve_source_profile(name, profile)
+      source_profile = profile.source_profile
+      if profiles.key? source_profile
+        profile['source_profile'] = profiles[source_profile]
+      else
+        (wanted_profiles[source_profile] ||= []) << name
+      end
+    end
+
+    def provides_source_profile(name, profile)
+      return unless wanted_profiles.key? name
+      wanted_profiles[name].each do |wanted_by|
+        profiles[wanted_by]['source_profile'] = profile
+      end
+      wanted_profiles.delete name
+    end
+  end
+end

--- a/lib/aws_config/profile_resolver.rb
+++ b/lib/aws_config/profile_resolver.rb
@@ -1,4 +1,4 @@
-require 'aws_config/profile'
+require "aws_config/profile"
 
 module AWSConfig
   class ProfileResolver
@@ -16,7 +16,7 @@ module AWSConfig
         else
           profiles[name] = profile
         end
-        resolve_source_profile(name, profile) if profile.has_key? 'source_profile'
+        resolve_source_profile(name, profile) if profile.has_key? "source_profile"
         provides_source_profile(name, profile)
       end
     end
@@ -26,7 +26,7 @@ module AWSConfig
     def resolve_source_profile(name, profile)
       source_profile = profile.source_profile
       if profiles.key? source_profile
-        profile['source_profile'] = profiles[source_profile]
+        profile["source_profile"] = profiles[source_profile]
       else
         (wanted_profiles[source_profile] ||= []) << name
       end
@@ -35,7 +35,7 @@ module AWSConfig
     def provides_source_profile(name, profile)
       return unless wanted_profiles.key? name
       wanted_profiles[name].each do |wanted_by|
-        profiles[wanted_by]['source_profile'] = profile
+        profiles[wanted_by]["source_profile"] = profile
       end
       wanted_profiles.delete name
     end

--- a/lib/aws_config/store.rb
+++ b/lib/aws_config/store.rb
@@ -1,9 +1,13 @@
+require 'aws_config/profile_resolver'
 module AWSConfig
   module Store
     def profiles
       @profiles ||= begin
         if File.exists?(config_file)
-          Parser.parse(File.read(config_file))
+          profile_resolver = ProfileResolver.new
+          profile_resolver.add Parser.parse(File.read(credentials_file), true)
+          profile_resolver.add Parser.parse(File.read(config_file))
+          profile_resolver.profiles
         else
           Hash.new
         end
@@ -16,6 +20,15 @@ module AWSConfig
 
     def config_file=(path)
       @config_file = path
+      @profiles = nil
+    end
+
+    def credentials_file
+      @credentials_file || ENV['AWS_SHARED_CREDENTIALS_FILE'] || File.join(ENV['HOME'], '.aws/credentials')
+    end
+
+    def credentials_file=(path)
+      @credentials_file = path
       @profiles = nil
     end
 

--- a/lib/aws_config/store.rb
+++ b/lib/aws_config/store.rb
@@ -1,4 +1,4 @@
-require 'aws_config/profile_resolver'
+require "aws_config/profile_resolver"
 module AWSConfig
   module Store
     def profiles
@@ -24,7 +24,7 @@ module AWSConfig
     end
 
     def credentials_file
-      @credentials_file || ENV['AWS_SHARED_CREDENTIALS_FILE'] || File.join(ENV['HOME'], '.aws/credentials')
+      @credentials_file || ENV["AWS_SHARED_CREDENTIALS_FILE"] || File.join(ENV["HOME"], ".aws/credentials")
     end
 
     def credentials_file=(path)

--- a/spec/lib/aws_config/parser_spec.rb
+++ b/spec/lib/aws_config/parser_spec.rb
@@ -60,13 +60,13 @@ aws_access_key_id=DefaultAccessKey01
       end
     end
 
-    context 'in credential file mode' do
+    context "in credential file mode" do
       subject do
         sut = described_class.new
         sut.credential_file_mode = true
         sut.send(:tokenize, string)
       end
-      context 'with only the default profile' do
+      context "with only the default profile" do
         let(:string) do
           <<-EOC
             [default]
@@ -75,13 +75,13 @@ aws_access_key_id=DefaultAccessKey01
           EOC
         end
         it { should eq [
-          [:profile,    'default'],
-          [:key_value,  'aws_access_key_id',      'DefaultAccessKey01'],
-          [:key_value,  'aws_secret_access_key',  'Default/Secret/Access/Key/02'],
+          [:profile,    "default"],
+          [:key_value,  "aws_access_key_id",      "DefaultAccessKey01"],
+          [:key_value,  "aws_secret_access_key",  "Default/Secret/Access/Key/02"],
         ] }
       end
 
-      context 'with the default and named profiles' do
+      context "with the default and named profiles" do
         let(:string) do
           <<-EOC
             [default]
@@ -92,10 +92,10 @@ aws_access_key_id=DefaultAccessKey01
           EOC
         end
         it { should eq [
-          [:profile,    'default'],
-          [:key_value,  'aws_access_key_id',  'DefaultAccessKey01'],
-          [:profile,    'testing'],
-          [:key_value,  'aws_access_key_id',  'TestingAccessKey03'],
+          [:profile,    "default"],
+          [:key_value,  "aws_access_key_id",  "DefaultAccessKey01"],
+          [:profile,    "testing"],
+          [:key_value,  "aws_access_key_id",  "TestingAccessKey03"],
         ] }
       end
     end

--- a/spec/lib/aws_config/parser_spec.rb
+++ b/spec/lib/aws_config/parser_spec.rb
@@ -59,6 +59,46 @@ aws_access_key_id=DefaultAccessKey01
         ] }
       end
     end
+
+    context 'in credential file mode' do
+      subject do
+        sut = described_class.new
+        sut.credential_file_mode = true
+        sut.send(:tokenize, string)
+      end
+      context 'with only the default profile' do
+        let(:string) do
+          <<-EOC
+            [default]
+            aws_access_key_id=DefaultAccessKey01
+            aws_secret_access_key=Default/Secret/Access/Key/02
+          EOC
+        end
+        it { should eq [
+          [:profile,    'default'],
+          [:key_value,  'aws_access_key_id',      'DefaultAccessKey01'],
+          [:key_value,  'aws_secret_access_key',  'Default/Secret/Access/Key/02'],
+        ] }
+      end
+
+      context 'with the default and named profiles' do
+        let(:string) do
+          <<-EOC
+            [default]
+            aws_access_key_id=DefaultAccessKey01
+
+            [testing]
+            aws_access_key_id=TestingAccessKey03
+          EOC
+        end
+        it { should eq [
+          [:profile,    'default'],
+          [:key_value,  'aws_access_key_id',  'DefaultAccessKey01'],
+          [:profile,    'testing'],
+          [:key_value,  'aws_access_key_id',  'TestingAccessKey03'],
+        ] }
+      end
+    end
   end
 
   describe "#build" do
@@ -67,7 +107,7 @@ aws_access_key_id=DefaultAccessKey01
     context "Single profile" do
       let(:tokens) { [
         [:profile,    "default"],
-        [:key_value,  "aws_access_key_id",      "DefaultAccessKey01"], 
+        [:key_value,  "aws_access_key_id",      "DefaultAccessKey01"],
         [:key_value,  "aws_secret_access_key",  "Default/Secret/Access/Key/02"],
         [:key_value,  "region",                 "us-west-1"]
       ] }
@@ -83,9 +123,9 @@ aws_access_key_id=DefaultAccessKey01
     context "Multi profiles" do
       let(:tokens) { [
         [:profile,    "default"],
-        [:key_value,  "aws_access_key_id",  "DefaultAccessKey01"], 
+        [:key_value,  "aws_access_key_id",  "DefaultAccessKey01"],
         [:profile,    "testing"],
-        [:key_value,  "aws_access_key_id",  "TestingAccessKey02"], 
+        [:key_value,  "aws_access_key_id",  "TestingAccessKey02"],
       ] }
       it { should eq({
         "default" => { "aws_access_key_id" => "DefaultAccessKey01" },
@@ -96,11 +136,11 @@ aws_access_key_id=DefaultAccessKey01
     context "Twice-defined single profile" do
       let(:tokens) { [
         [:profile,    "default"],
-        [:key_value,  "aws_access_key_id",      "DefaultAccessKey01"], 
+        [:key_value,  "aws_access_key_id",      "DefaultAccessKey01"],
         [:key_value,  "region",                 "us-west-1"],
         [:profile,    "default"],
-        [:key_value,  "aws_access_key_id",      "DefaultAccessKey01_ANOTHER"], 
-        [:key_value,  "aws_secret_access_key",  "Default/Secret/Access/Key/01"], 
+        [:key_value,  "aws_access_key_id",      "DefaultAccessKey01_ANOTHER"],
+        [:key_value,  "aws_secret_access_key",  "Default/Secret/Access/Key/01"],
       ] }
       it { should eq({
         "default" => {

--- a/spec/lib/aws_config/profile_resolver_spec.rb
+++ b/spec/lib/aws_config/profile_resolver_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+describe AWSConfig::ProfileResolver do
+  subject { described_class.new }
+
+  let(:default_profile) do
+    AWSConfig::Profile.new(
+      'default',
+      'aws_access_key_id'     => 'DefaultAccessId01',
+      'aws_secret_access_key' => 'DefaultSecretKey01',
+      'region'            => 'us-west-1'
+    )
+  end
+  let(:testing_profile) do
+    AWSConfig::Profile.new(
+      'testing',
+      'aws_access_key_id'     => 'TestingAccessId01',
+      'aws_secret_access_key' => 'TestingSecretKey01',
+      'region'            => 'us-west-1'
+    )
+  end
+  let(:profile_with_source) do
+    AWSConfig::Profile.new(
+      'with_source',
+      'region'     => 'ap-southeast-2',
+      'source_profile' => 'testing'
+    )
+  end
+  describe '#add' do
+    context 'when all profiles resolve' do
+      let(:profiles) do
+        {
+          default_profile.name     => default_profile,
+          testing_profile.name     => testing_profile,
+          profile_with_source.name => profile_with_source
+        }
+      end
+
+      it 'resolves the sources' do
+        subject.add profiles
+        expect(profiles['with_source'].source_profile).to be testing_profile
+      end
+    end
+
+    context 'when some profles do not resolve' do
+      let(:unresolving) do
+        AWSConfig::Profile.new(
+          'unresolving',
+          'aws_access_key_id'     => 'UnresolvingAccessId01',
+          'aws_secret_access_key' => 'UnresolvingSecretKey01',
+          'region'            => 'us-west-1',
+          'source_profile'        => 'doesnt_exist'
+        )
+      end
+
+      let(:missing_profile) do
+        AWSConfig::Profile.new(
+          'doesnt_exist',
+          'aws_session_token' => 'uk-west-2'
+        )
+      end
+      let(:profiles) do
+        {
+          default_profile.name     => default_profile,
+          testing_profile.name     => testing_profile,
+          profile_with_source.name => profile_with_source,
+          unresolving.name         => unresolving
+        }
+      end
+
+      it 'resolves the sources it can' do
+        subject.add profiles
+        expect(profiles['with_source'].source_profile).to be testing_profile
+      end
+
+      it 'should remember the unresolved source profile' do
+        subject.add profiles
+        expect(subject.wanted_profiles).to eq('doesnt_exist' => ['unresolving'])
+      end
+
+      it 'should resolve the missing profile if it is added later' do
+        subject.add profiles
+        expect(subject.wanted_profiles).to eq('doesnt_exist' => ['unresolving'])
+        subject.add missing_profile.name => missing_profile
+        expect(subject.wanted_profiles).to eq({})
+        expect(subject.profiles['unresolving'].source_profile).to be missing_profile
+      end
+    end
+  end
+end

--- a/spec/lib/aws_config/profile_resolver_spec.rb
+++ b/spec/lib/aws_config/profile_resolver_spec.rb
@@ -1,33 +1,33 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe AWSConfig::ProfileResolver do
   subject { described_class.new }
 
   let(:default_profile) do
     AWSConfig::Profile.new(
-      'default',
-      'aws_access_key_id'     => 'DefaultAccessId01',
-      'aws_secret_access_key' => 'DefaultSecretKey01',
-      'region'            => 'us-west-1'
+      "default",
+      "aws_access_key_id"     => "DefaultAccessId01",
+      "aws_secret_access_key" => "DefaultSecretKey01",
+      "region"            => "us-west-1"
     )
   end
   let(:testing_profile) do
     AWSConfig::Profile.new(
-      'testing',
-      'aws_access_key_id'     => 'TestingAccessId01',
-      'aws_secret_access_key' => 'TestingSecretKey01',
-      'region'            => 'us-west-1'
+      "testing",
+      "aws_access_key_id"     => "TestingAccessId01",
+      "aws_secret_access_key" => "TestingSecretKey01",
+      "region"            => "us-west-1"
     )
   end
   let(:profile_with_source) do
     AWSConfig::Profile.new(
-      'with_source',
-      'region'     => 'ap-southeast-2',
-      'source_profile' => 'testing'
+      "with_source",
+      "region"     => "ap-southeast-2",
+      "source_profile" => "testing"
     )
   end
-  describe '#add' do
-    context 'when all profiles resolve' do
+  describe "#add" do
+    context "when all profiles resolve" do
       let(:profiles) do
         {
           default_profile.name     => default_profile,
@@ -36,27 +36,27 @@ describe AWSConfig::ProfileResolver do
         }
       end
 
-      it 'resolves the sources' do
+      it "resolves the sources" do
         subject.add profiles
-        expect(profiles['with_source'].source_profile).to be testing_profile
+        expect(profiles["with_source"].source_profile).to be testing_profile
       end
     end
 
-    context 'when some profles do not resolve' do
+    context "when some profles do not resolve" do
       let(:unresolving) do
         AWSConfig::Profile.new(
-          'unresolving',
-          'aws_access_key_id'     => 'UnresolvingAccessId01',
-          'aws_secret_access_key' => 'UnresolvingSecretKey01',
-          'region'            => 'us-west-1',
-          'source_profile'        => 'doesnt_exist'
+          "unresolving",
+          "aws_access_key_id"     => "UnresolvingAccessId01",
+          "aws_secret_access_key" => "UnresolvingSecretKey01",
+          "region"            => "us-west-1",
+          "source_profile"        => "doesnt_exist"
         )
       end
 
       let(:missing_profile) do
         AWSConfig::Profile.new(
-          'doesnt_exist',
-          'aws_session_token' => 'uk-west-2'
+          "doesnt_exist",
+          "aws_session_token" => "uk-west-2"
         )
       end
       let(:profiles) do
@@ -68,22 +68,22 @@ describe AWSConfig::ProfileResolver do
         }
       end
 
-      it 'resolves the sources it can' do
+      it "resolves the sources it can" do
         subject.add profiles
-        expect(profiles['with_source'].source_profile).to be testing_profile
+        expect(profiles["with_source"].source_profile).to be testing_profile
       end
 
-      it 'should remember the unresolved source profile' do
+      it "should remember the unresolved source profile" do
         subject.add profiles
-        expect(subject.wanted_profiles).to eq('doesnt_exist' => ['unresolving'])
+        expect(subject.wanted_profiles).to eq("doesnt_exist" => ["unresolving"])
       end
 
-      it 'should resolve the missing profile if it is added later' do
+      it "should resolve the missing profile if it is added later" do
         subject.add profiles
-        expect(subject.wanted_profiles).to eq('doesnt_exist' => ['unresolving'])
+        expect(subject.wanted_profiles).to eq("doesnt_exist" => ["unresolving"])
         subject.add missing_profile.name => missing_profile
         expect(subject.wanted_profiles).to eq({})
-        expect(subject.profiles['unresolving'].source_profile).to be missing_profile
+        expect(subject.profiles["unresolving"].source_profile).to be missing_profile
       end
     end
   end

--- a/spec/lib/aws_config/profile_spec.rb
+++ b/spec/lib/aws_config/profile_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe AWSConfig::Profile do
-  context 'regardless of source_profile' do
+  context "regardless of source_profile" do
     subject {
       AWSConfig::Profile.new(
         "default",
@@ -46,45 +46,45 @@ describe AWSConfig::Profile do
     end
   end
 
-  context 'with source_profile' do
+  context "with source_profile" do
     let(:source_profile) do
       AWSConfig::Profile.new(
-        'default',
-        'region'            => 'ap-southeast-2',
-        'aws_access_key_id'     => 'DefaultAccessKey01',
-        'aws_secret_access_key' => 'Default/Secret/Access/Key/02'
+        "default",
+        "region"            => "ap-southeast-2",
+        "aws_access_key_id"     => "DefaultAccessKey01",
+        "aws_secret_access_key" => "Default/Secret/Access/Key/02"
       )
     end
     subject do
       AWSConfig::Profile.new(
-        'testing',
-        'region'          => 'us-west-1',
-        'source_profile'  => source_profile
+        "testing",
+        "region"          => "us-west-1",
+        "source_profile"  => source_profile
       )
     end
-    context 'when called like a method' do
-      let(:region) { 'us-west-1' }
-      let(:access_key_id) { 'DefaultAccesskey01' }
-      it 'should return values directly on the profile' do
+    context "when called like a method" do
+      let(:region) { "us-west-1" }
+      let(:access_key_id) { "DefaultAccesskey01" }
+      it "should return values directly on the profile" do
         expect(subject.region).to eq region
       end
 
-      it 'should check the source profile if the desired key is missing' do
+      it "should check the source profile if the desired key is missing" do
         expect(source_profile).to receive(:aws_access_key_id).and_return(access_key_id)
         expect(subject.aws_access_key_id).to eq access_key_id
       end
     end
 
-    context 'when called like a hash' do
-      let(:region) { 'us-west-1' }
-      let(:access_key_id) { 'DefaultAccesskey01' }
-      it 'should return values directly on the profile' do
-        expect(subject['region']).to eq region
+    context "when called like a hash" do
+      let(:region) { "us-west-1" }
+      let(:access_key_id) { "DefaultAccesskey01" }
+      it "should return values directly on the profile" do
+        expect(subject["region"]).to eq region
       end
 
-      it 'should check the source profile if the desired key is missing' do
-        expect(source_profile).to receive(:[]).with('aws_access_key_id').and_return(access_key_id)
-        expect(subject['aws_access_key_id']).to eq access_key_id
+      it "should check the source profile if the desired key is missing" do
+        expect(source_profile).to receive(:[]).with("aws_access_key_id").and_return(access_key_id)
+        expect(subject["aws_access_key_id"]).to eq access_key_id
       end
     end
   end

--- a/spec/lib/aws_config/profile_spec.rb
+++ b/spec/lib/aws_config/profile_spec.rb
@@ -1,46 +1,91 @@
 require "spec_helper"
 
 describe AWSConfig::Profile do
-  subject {
-    AWSConfig::Profile.new(
-      "default",
-      "aws_access_key_id"     => "DefaultAccessKey01",
-      "aws_secret_access_key" => "Default/Secret/Access/Key/02",
-      "region"                => "us-west-1"
-    )
-  }
+  context 'regardless of source_profile' do
+    subject {
+      AWSConfig::Profile.new(
+        "default",
+        "aws_access_key_id"     => "DefaultAccessKey01",
+        "aws_secret_access_key" => "Default/Secret/Access/Key/02",
+        "region"                => "us-west-1"
+      )
+    }
 
-  it "should return given name via method" do
-    expect(subject.name).to eq "default"
+    it "should return given name via method" do
+      expect(subject.name).to eq "default"
+    end
+
+    it "should respond to methods whose names are same as given entries" do
+      expect(subject).to respond_to :aws_access_key_id
+      expect(subject).to respond_to :aws_secret_access_key
+      expect(subject).to respond_to :region
+    end
+
+    it "should return given entries via methods" do
+      expect(subject.aws_access_key_id).to eq "DefaultAccessKey01"
+      expect(subject.aws_secret_access_key).to eq "Default/Secret/Access/Key/02"
+      expect(subject.region).to eq "us-west-1"
+    end
+
+    it "should return given entries via hash-like methods" do
+      expect(subject[:aws_access_key_id]).to eq "DefaultAccessKey01"
+      expect(subject[:aws_secret_access_key]).to eq "Default/Secret/Access/Key/02"
+      expect(subject[:region]).to eq "us-west-1"
+    end
+
+    it "should raise exceptions if unknown entry is called via methods" do
+      expect { subject.unknown_method }.to raise_error NoMethodError
+    end
+
+    it "should return a hash for aws-sdk-ruby's configuration format" do
+      expect(subject.config_hash).to eq({
+        access_key_id:      "DefaultAccessKey01",
+        secret_access_key:  "Default/Secret/Access/Key/02",
+        region:             "us-west-1"
+      })
+    end
   end
 
-  it "should respond to methods whose names are same as given entries" do
-    expect(subject).to respond_to :aws_access_key_id
-    expect(subject).to respond_to :aws_secret_access_key
-    expect(subject).to respond_to :region
-  end
+  context 'with source_profile' do
+    let(:source_profile) do
+      AWSConfig::Profile.new(
+        'default',
+        'region'            => 'ap-southeast-2',
+        'aws_access_key_id'     => 'DefaultAccessKey01',
+        'aws_secret_access_key' => 'Default/Secret/Access/Key/02'
+      )
+    end
+    subject do
+      AWSConfig::Profile.new(
+        'testing',
+        'region'          => 'us-west-1',
+        'source_profile'  => source_profile
+      )
+    end
+    context 'when called like a method' do
+      let(:region) { 'us-west-1' }
+      let(:access_key_id) { 'DefaultAccesskey01' }
+      it 'should return values directly on the profile' do
+        expect(subject.region).to eq region
+      end
 
-  it "should return given entries via methods" do
-    expect(subject.aws_access_key_id).to eq "DefaultAccessKey01"
-    expect(subject.aws_secret_access_key).to eq "Default/Secret/Access/Key/02"
-    expect(subject.region).to eq "us-west-1"
-  end
+      it 'should check the source profile if the desired key is missing' do
+        expect(source_profile).to receive(:aws_access_key_id).and_return(access_key_id)
+        expect(subject.aws_access_key_id).to eq access_key_id
+      end
+    end
 
-  it "should return given entries via hash-like methods" do
-    expect(subject[:aws_access_key_id]).to eq "DefaultAccessKey01"
-    expect(subject[:aws_secret_access_key]).to eq "Default/Secret/Access/Key/02"
-    expect(subject[:region]).to eq "us-west-1"
-  end
+    context 'when called like a hash' do
+      let(:region) { 'us-west-1' }
+      let(:access_key_id) { 'DefaultAccesskey01' }
+      it 'should return values directly on the profile' do
+        expect(subject['region']).to eq region
+      end
 
-  it "should raise exceptions if unknown entry is called via methods" do
-    expect { subject.unknown_method }.to raise_error NoMethodError
-  end
-
-  it "should return a hash for aws-sdk-ruby's configuration format" do
-    expect(subject.config_hash).to eq({
-      access_key_id:      "DefaultAccessKey01",
-      secret_access_key:  "Default/Secret/Access/Key/02",
-      region:             "us-west-1"
-    })
+      it 'should check the source profile if the desired key is missing' do
+        expect(source_profile).to receive(:[]).with('aws_access_key_id').and_return(access_key_id)
+        expect(subject['aws_access_key_id']).to eq access_key_id
+      end
+    end
   end
 end

--- a/spec/lib/aws_config_spec.rb
+++ b/spec/lib/aws_config_spec.rb
@@ -2,7 +2,11 @@ require "spec_helper"
 
 describe AWSConfig do
   let(:sample_config_file) { File.expand_path("../../samples/config.txt", __FILE__) }
-  before { AWSConfig.config_file = sample_config_file }
+  let(:sample_creds_file) { File.expand_path("../../samples/credentials.txt", __FILE__) }
+  before do
+    AWSConfig.config_file = sample_config_file
+    AWSConfig.credentials_file = sample_creds_file
+  end
 
   it "should return an entry in a profile via method" do
     expect(described_class.default.aws_access_key_id).to eq "DefaultAccessKey01"

--- a/spec/samples/config.txt
+++ b/spec/samples/config.txt
@@ -1,10 +1,8 @@
 [default]
-aws_access_key_id=DefaultAccessKey01
-aws_secret_access_key=Default/Secret/Access/Key/02
 # Optional, to define default region for this profile.
 region=us-west-1
+source_profile=default
 
 [profile testing]
-aws_access_key_id=TestingAccessKey03
-aws_secret_access_key=Testing/Secret/Access/Key/04
 region=us-west-2
+source_profile=testing

--- a/spec/samples/credentials.txt
+++ b/spec/samples/credentials.txt
@@ -1,0 +1,7 @@
+[default]
+aws_access_key_id=DefaultAccessKey01
+aws_secret_access_key=Default/Secret/Access/Key/02
+
+[testing]
+aws_access_key_id=TestingAccessKey03
+aws_secret_access_key=Testing/Secret/Access/Key/04


### PR DESCRIPTION
This Pull Request adds support for chained profiles in AWS CLI Config files using the `source_profile` property.

To achieve this I also had to add support for parsing the AWS Shared Credentials file as often the chained profiles credentials are stored in there.

Please comment with any changes you can recommend

Closes #2 
Closes #4 