### PR TITLE
Support nested config options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+vendor

--- a/lib/aws_config/parser.rb
+++ b/lib/aws_config/parser.rb
@@ -27,7 +27,7 @@ module AWSConfig
       current_nesting = nil
 
       string.lines.each do |line|
-        comment = line.match(/\s*#.*/)
+        comment = line.match(/^\s*#.*/)
         blank = line.match(/^\s*$/)
         next if comment || blank
 

--- a/lib/aws_config/parser.rb
+++ b/lib/aws_config/parser.rb
@@ -6,70 +6,58 @@ module AWSConfig
     attr_accessor :credential_file_mode
 
     def self.parse(string, credential_file_mode = false)
-      parser = new
-      parser.credential_file_mode = credential_file_mode
-      parser.parse(string)
+      from_hash(new.tokenize(string))
     end
 
-    def parse(string)
-      wrap(build(tokenize(string)))
+    def self.from_hash(hash)
+      hash.inject({}) do |memo, (k,v)|
+        if v.is_a?(Hash)
+          memo[k]=Profile.new(k,v)
+        else
+          memo[k] = v
+        end
+
+        memo
+      end
     end
 
-    private
+    def tokenize(string)
+      tokens = { }
+      current_profile = nil
+      current_nesting = nil
 
-      def tokenize(string)
-        s = StringScanner.new(string)
-        tokens  = []
+      string.lines.each do |line|
+        comment = line.match(/\s*#.*/)
+        blank = line.match(/^\s*$/)
+        next if comment || blank
 
-        until s.eos?
-          if s.scan(/\[\s*([^\]]+)\s*\]/)
-            if s[1] == "default"
-              tokens << [:profile, "default"]
-            elsif m = s[1].match(/profile\s+([^\s]+)$/)
-              tokens << [:profile, m[1]]
-            elsif credential_file_mode
-              tokens << [:profile, s[1]]
-            end
-          elsif s.scan(/([^\s=#]+)\s*=\s*([^\s#]+)/)
-            tokens << [:key_value, s[1], s[2]]
-          elsif s.scan(/#[^\n]*/)
-          elsif s.scan(/\s+/)
-          elsif s.scan(/\n+/)
+        profile_match = line.match(/\[\s*(profile)?\s*(?<profile>[^\]]+)\s*\]/)
+        if profile_match
+          current_profile = profile_match[:profile]
+          tokens[current_profile] ||= {}
+          next
+        end
+
+        nest_key_value = line.match(/(?<nest>^\s+)?(?<key>[^\s=#]+)\s*=\s*(?<value>[^\s#]+)/)
+        if nest_key_value
+          nest, key, value = !!nest_key_value[:nest], nest_key_value[:key], nest_key_value[:value]
+          if nest
+            fail("Nesting without a parent error") if current_nesting.nil?
+            tokens[current_profile][current_nesting][key] = value
           else
-            s.scan(/./)
-            raise "Invalid token `#{s[0]}` as #{s.pos}"
+            current_nesting = nil
+            tokens[current_profile][key] = value
           end
+          next
         end
 
-        tokens
-      end
-
-      def build(tokens)
-        tokens = tokens.dup
-        profiles = {}
-        profile = nil
-
-        while values = tokens.shift
-          head = values.shift
-
-          case head
-          when :profile
-            profile = profiles[values[0]] ||= {}
-          when :key_value
-            if profile
-              profile[values[0]] = values[1]
-            end
-          end
-        end
-
-        profiles
-      end
-
-      def wrap(profiles)
-        profiles.inject({}) do |s, (name, properties)|
-          s[name] = Profile.new(name, properties)
-          s
+        nesting = line.match(/(?<name>[^\s=#]+)\s*=.*/)
+        if nesting
+          current_nesting = nesting[:name]
+          tokens[current_profile][current_nesting] ||= {}
         end
       end
+      tokens
+    end
   end
 end

--- a/lib/aws_config/profile.rb
+++ b/lib/aws_config/profile.rb
@@ -58,15 +58,8 @@ module AWSConfig
       }
     end
 
-    # Returns a new profile from the two merged profiles
-    def merge(profile)
-      merged = entries.dup
-      merged.merge! profile.entries
-      new name, merged
-    end
-
-    def merge!(profile)
-      entries.merge! profile.entries
+    def merge!(other)
+      @entries = Parser.from_hash(entries.merge(other.entries))
       self
     end
   end

--- a/spec/lib/aws_config/parser_spec.rb
+++ b/spec/lib/aws_config/parser_spec.rb
@@ -11,12 +11,12 @@ aws_access_key_id=DefaultAccessKey01
 aws_secret_access_key=Default/Secret/Access/Key/02
 region=us-west-1
       EOC
-      it { should eq({
+      it { should eq(
         "default" => {
           "aws_access_key_id" => "DefaultAccessKey01",
           "aws_secret_access_key" => "Default/Secret/Access/Key/02",
           "region" => "us-west-1" }
-      }) }
+      ) }
     end
 
     context "with nesting" do
@@ -28,7 +28,7 @@ s3=
   max_queue_size=20
 output=json
       EOC
-      it { should eq({
+      it { should eq(
         "default" => {
           "region" => "us-east-1",
           "s3" => {
@@ -36,7 +36,7 @@ output=json
             "max_queue_size" => "20"
           },
           "output" => "json" }
-      }) }
+      ) }
     end
 
     context "invalid nesting" do
@@ -65,7 +65,7 @@ api_versions =
     ec2 = 2015-03-01
     cloudfront = 2015-09-17
       EOC
-      it { should eq({
+      it { should eq(
         "default" => {
           "region" => "us-east-1",
           "s3" => {
@@ -76,8 +76,28 @@ api_versions =
           "api_versions" => {
             "ec2" => "2015-03-01",
             "cloudfront" => "2015-09-17"
-          } }
-      }) }
+          }
+        }
+      ) }
+    end
+
+    context "with comments" do
+      let(:string) { <<-EOC }
+[default] # inline comment in a profile
+region=us-east-1 # inline comment in top level element
+s3= # inline comment in nesting openning
+  max_concurrent_requests=100101 # inline comment in a nested element
+  # comment prefixed with spaces
+# comment in a new line
+      EOC
+      it { should eq(
+        "default" => {
+          "region" => "us-east-1",
+          "s3" => {
+            "max_concurrent_requests" => "100101",
+          }
+        }
+      ) }
     end
 
     context "default and named profiles" do
@@ -88,10 +108,10 @@ aws_access_key_id=DefaultAccessKey01
 [profile testing]
 aws_access_key_id=TestingAccessKey03
       EOC
-      it { should eq({
+      it { should eq(
         "default" => { "aws_access_key_id" => "DefaultAccessKey01" },
         "testing" => { "aws_access_key_id" => "TestingAccessKey03" }
-      })}
+      ) }
 
       context "Comment line" do
         let(:string) { <<-EOC }
@@ -99,9 +119,9 @@ aws_access_key_id=TestingAccessKey03
 # THIS IS COMMENT #
 aws_access_key_id=DefaultAccessKey01
         EOC
-        it { should eq({
+        it { should eq(
           "default" => { "aws_access_key_id" => "DefaultAccessKey01" }
-        }) }
+        ) }
       end
 
       context "Blank line" do
@@ -111,9 +131,9 @@ aws_access_key_id=DefaultAccessKey01
 
 aws_access_key_id=DefaultAccessKey01
         EOC
-        it { should eq({
+        it { should eq(
           "default" => { "aws_access_key_id" => "DefaultAccessKey01" }
-        }) }
+        ) }
       end
     end
 
@@ -129,11 +149,12 @@ aws_access_key_id=DefaultAccessKey01
 aws_access_key_id=DefaultAccessKey01
 aws_secret_access_key=Default/Secret/Access/Key/02
         EOC
-        it { should eq({
+        it { should eq(
           "default" => {
-            "aws_access_key_id" => "DefaultAccessKey01", "aws_secret_access_key" => "Default/Secret/Access/Key/02"
-           }
-        }) }
+            "aws_access_key_id" => "DefaultAccessKey01",
+            "aws_secret_access_key" => "Default/Secret/Access/Key/02"
+          }
+        ) }
       end
 
       context "with the default and named profiles" do
@@ -144,10 +165,10 @@ aws_access_key_id=DefaultAccessKey01
 [testing]
 aws_access_key_id=TestingAccessKey03
         EOC
-        it { should eq({
+        it { should eq(
           "default" => { "aws_access_key_id" => "DefaultAccessKey01" },
           "testing" => { "aws_access_key_id" => "TestingAccessKey03" }
-        }) }
+        ) }
       end
     end
   end

--- a/spec/lib/aws_config_spec.rb
+++ b/spec/lib/aws_config_spec.rb
@@ -20,7 +20,8 @@ describe AWSConfig do
     expect(described_class["default"]["aws_access_key_id"]).to eq "DefaultAccessKey01"
     expect(described_class["default"]["region"]).to eq "us-west-1"
     expect(described_class["default"]["output"]).to eq "json"
-    expect(described_class["default"]["s3"]["max_concurrent_requests"]).to eq "100101"
+    expect(described_class["default"]["s3"]["max_concurrent_requests"]).
+      to eq "100101"
     expect(described_class["default"]["s3"]["max_queue_size"]).to eq "20"
   end
 end

--- a/spec/lib/aws_config_spec.rb
+++ b/spec/lib/aws_config_spec.rb
@@ -11,10 +11,16 @@ describe AWSConfig do
   it "should return an entry in a profile via method" do
     expect(described_class.default.aws_access_key_id).to eq "DefaultAccessKey01"
     expect(described_class.default.region).to eq "us-west-1"
+    expect(described_class.default.output).to eq "json"
+    expect(described_class.default.s3.max_concurrent_requests).to eq "100101"
+    expect(described_class.default.s3.max_queue_size).to eq "20"
   end
 
   it "should return an entry in a profile like hashes" do
     expect(described_class["default"]["aws_access_key_id"]).to eq "DefaultAccessKey01"
     expect(described_class["default"]["region"]).to eq "us-west-1"
+    expect(described_class["default"]["output"]).to eq "json"
+    expect(described_class["default"]["s3"]["max_concurrent_requests"]).to eq "100101"
+    expect(described_class["default"]["s3"]["max_queue_size"]).to eq "20"
   end
 end

--- a/spec/samples/config.txt
+++ b/spec/samples/config.txt
@@ -2,7 +2,13 @@
 # Optional, to define default region for this profile.
 region=us-west-1
 source_profile=default
+# Nested
+s3=
+  max_concurrent_requests=100101
+  max_queue_size=20
+output=json
 
 [profile testing]
 region=us-west-2
 source_profile=testing
+


### PR DESCRIPTION
Fixes #6 

This allows access to nested config options of AWS.

Given the following config:
```
[default]
region=ap-southeast-2
s3=
    max_concurrent_requests=100101
    max_queue_size=20
```

It's possible to access nested attributes normally

```
AWSConfig.default.s3.max_queue_size
```

Nesting without a parent is not allowed, given the following config:

```
[default]
region=ap-southeast-2
    max_concurrent_requests=100101
```

An exception will be thrown.

Only single level of nesting is allowed, I'm not sure if AWS allows
multiple levels of nesting anywhere. However implementation will be
possible, we can track _depth_.

Parser / tokenizer has been rewritten, now it produces a hash. The
hash reflects structure of a config file and (hopefully) makes it
easier to understand.

---

A perhaps awkward change to the tests:

```
-        let(:string) do
-          <<-EOC
-            [default]
-            aws_access_key_id=DefaultAccessKey01
-            aws_secret_access_key=Default/Secret/Access/Key/02
-          EOC
-        end
```

this would maintain whitespaces in front of each line that I think are not allowed by AWS (and even more not allowed with nesting support), I may be wrong here tho.

Also nesting reuses Profile class, and it may be a little confusing, i.e. `default.s3.name` would return `s3` since. It's not affecting how the library works, just something that is not obvious. Given the ProfileResolver maintains all the logic it should be safe to deprecate `name` completely or even change `Profile` to something else, perhaps `Entry`? I didn't do it here because I'm not sure you'd like the idea and I wanted to limit scope of this p/r.