### PR TITLE
Fix aws config lookup

### DIFF
--- a/lib/aws_config/store.rb
+++ b/lib/aws_config/store.rb
@@ -10,9 +10,7 @@ module AWSConfig
             profile_resolver.add Parser.parse(File.read(credentials_file), true)
           end
 
-          if File.exist?(config_file)
-            profile_resolver.add Parser.parse(File.read(config_file))
-          end
+          profile_resolver.add Parser.parse(File.read(config_file))
 
           profile_resolver.profiles
         else

--- a/lib/aws_config/store.rb
+++ b/lib/aws_config/store.rb
@@ -5,8 +5,15 @@ module AWSConfig
       @profiles ||= begin
         if File.exist?(config_file)
           profile_resolver = ProfileResolver.new
-          profile_resolver.add Parser.parse(File.read(credentials_file), true)
-          profile_resolver.add Parser.parse(File.read(config_file))
+
+          if File.exist?(credentials_file)
+            profile_resolver.add Parser.parse(File.read(credentials_file), true)
+          end
+
+          if File.exist?(config_file)
+            profile_resolver.add Parser.parse(File.read(config_file))
+          end
+
           profile_resolver.profiles
         else
           Hash.new

--- a/spec/lib/aws_config_spec.rb
+++ b/spec/lib/aws_config_spec.rb
@@ -24,4 +24,22 @@ describe AWSConfig do
       to eq "100101"
     expect(described_class["default"]["s3"]["max_queue_size"]).to eq "20"
   end
+
+  context 'when the credentials file is missing' do
+    let(:sample_creds_file) { nil }
+
+    it 'should return profiles from the config' do
+      expect(described_class['testing-config-only'].aws_access_key_id).to eq "TestingConfigOnlyAccessKey01"
+      expect(described_class['testing-config-only'].region).to eq "us-west-2"
+    end
+  end
+
+  context 'when the config file is missing' do
+    let(:sample_config_file) { nil }
+
+    it 'should return profiles from the config' do
+      expect(described_class['testing-credentials-only'].aws_access_key_id).to eq "TestingCredentialsOnlyAccessKey01"
+      expect(described_class['testing-credentials-only'].region).to eq "us-west-2"
+    end
+  end
 end

--- a/spec/lib/aws_config_spec.rb
+++ b/spec/lib/aws_config_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe AWSConfig do
   let(:sample_config_file) { File.expand_path("../../samples/config.txt", __FILE__) }
   let(:sample_creds_file) { File.expand_path("../../samples/credentials.txt", __FILE__) }
+
   before do
     AWSConfig.config_file = sample_config_file
     AWSConfig.credentials_file = sample_creds_file

--- a/spec/samples/config.txt
+++ b/spec/samples/config.txt
@@ -12,3 +12,7 @@ output=json
 region=us-west-2
 source_profile=testing
 
+[profile testing-config-only]
+region=us-west-2
+aws_access_key_id=TestingConfigOnlyAccessKey01
+aws_secret_access_key=Testing/Secret/Access/Config/Only/Key/01

--- a/spec/samples/credentials.txt
+++ b/spec/samples/credentials.txt
@@ -5,3 +5,8 @@ aws_secret_access_key=Default/Secret/Access/Key/02
 [testing]
 aws_access_key_id=TestingAccessKey03
 aws_secret_access_key=Testing/Secret/Access/Key/04
+
+[profile testing-credentials-only]
+region=us-west-2
+aws_access_key_id=TestingCredentialsOnlyAccessKey01
+aws_secret_access_key=Testing/Secret/Access/Credentials/Only/Key/01


### PR DESCRIPTION
If a credentials file doesn't exist that should be ok!